### PR TITLE
Decode filename according to file system encoding

### DIFF
--- a/caja-extension/caja-mediainfo-tab.py
+++ b/caja-extension/caja-mediainfo-tab.py
@@ -64,7 +64,7 @@ class Mediainfo(GObject.GObject, Caja.PropertyPageProvider):
     if file.is_directory():
       return
 
-    filename = unquote(file.get_uri()[7:])
+    filename = unquote(file.get_uri()[7:]).decode(sys.getfilesystemencoding())
 
     MI = MediaInfo()
     MI.Option_Static("Complete")


### PR DESCRIPTION
Hi,
I suggest adding back the filename decoding according to file system encoding, so that the extension can work on files located in paths with special characters (eg "foo/Vidéos/ex.avi").
Thanks
Laurent